### PR TITLE
Fix exhausted connection throw tag

### DIFF
--- a/lib/ruby-h2/http-agent.rb
+++ b/lib/ruby-h2/http-agent.rb
@@ -1019,7 +1019,7 @@ yellow "--"
             until queue.empty?
               f = queue.first
               b = (f.type == FrameTypes::DATA ? f.payload_size : 0)
-              throw :CONNECTION_EXHAUSED if @window_size < b
+              throw :CONNECTION_EXHAUSTED if @window_size < b
               throw :STREAM_EXHAUSTED if s.window_size < b
               queue.shift
               @window_size -= b
@@ -1034,4 +1034,3 @@ yellow "--"
   end
 
 end
-

--- a/test/test_http_agent.rb
+++ b/test/test_http_agent.rb
@@ -1,0 +1,28 @@
+# encoding: BINARY
+# vim: ts=2:sts=2:sw=2
+
+require 'test/unit'
+$VERBOSE = true
+
+require_relative '../lib/ruby-h2/http-agent'
+
+class Test_http_agent < Test::Unit::TestCase
+
+	def test_window_update_stops_draining_when_connection_window_exhausted
+		agent = ::RUBYH2::HTTPAgent.new
+		stream = ::RUBYH2::Stream.new(65_535)
+		queued = ::RUBYH2::Frame.new(::RUBYH2::FrameTypes::DATA, 0, 1, 'abcdef')
+		update = ::RUBYH2::Frame.new(::RUBYH2::FrameTypes::WINDOW_UPDATE, 0, 0, [1].pack('N'))
+
+		agent.instance_variable_set(:@streams, {1 => stream})
+		agent.instance_variable_set(:@window_size, 0)
+		agent.instance_variable_set(:@window_queue, {1 => [queued]})
+
+		assert_nothing_raised do
+			agent.send(:handle_window_update, update)
+		end
+
+		assert_equal [queued], agent.instance_variable_get(:@window_queue)[1]
+	end
+
+end


### PR DESCRIPTION
Fixes #2.

## Summary
- corrected the connection-window drain `throw` tag from `:CONNECTION_EXHAUSED` to `:CONNECTION_EXHAUSTED`
- added a focused `test/unit` regression for a queued DATA frame that remains blocked after a connection-level `WINDOW_UPDATE`

## Validation
- `ruby test/test_http_agent.rb`
- `ruby test/test_encoding.rb`
- `ruby test/test_huffman_codes.rb`
- `rg -n "CONNECTION_EXHAUS" lib/ruby-h2/http-agent.rb test/test_http_agent.rb`
- `git diff --check`